### PR TITLE
Redis 6.0.8 is released

### DIFF
--- a/.github/workflows/build-6.0.yml
+++ b/.github/workflows/build-6.0.yml
@@ -14,6 +14,7 @@ jobs:
           - ubuntu-18.04
           - macos-latest
         redis:
+          - "6.0.8"
           - "6.0.7"
           - "6.0.6"
           - "6.0.5"


### PR DESCRIPTION
https://github.com/redis/redis/releases/tag/6.0.8