### PR TITLE
improve release flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-setup-redis",
-  "version": "1.0.1",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "actions-setup-redis",
-  "version": "1.0.1",
+  "version": "0.0.0",
   "private": true,
   "description": "setup redis database action",
   "main": "lib/setup-redis.js",

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -uex
+
+CURRENT=$(cd "$(dirname "$0")" && pwd)
+VERSION=$1
+MAJOR=$(echo "$VERSION" | cut -d. -f1)
+MINOR=$(echo "$VERSION" | cut -d. -f2)
+PATCH=$(echo "$VERSION" | cut -d. -f3)
+WORKING=$CURRENT/.working
+
+: clone
+ORIGIN=$(git remote get-url origin)
+rm -rf "$WORKING"
+git clone "$ORIGIN" "$WORKING"
+cd "$WORKING"
+
+git checkout -b "releases/v$MAJOR" "origin/releases/v$MAJOR" || git checkout -b "releases/v$MAJOR" main
+git merge -X theirs -m "Merge branch 'main' into releases/v$MAJOR" main || true
+
+: build the action
+jq ".version=\"$MAJOR.$MINOR.$PATCH\"" < package.json > .tmp.json
+mv .tmp.json package.json
+npm ci
+npm run build
+
+: remove development packages from node_modules
+npm prune --production
+perl -ne 'print unless m(^/node_modules/|/lib/$)' -i .gitignore
+
+: publish to GitHub
+git add .
+git commit -m "bump up to v$MAJOR.$MINOR.$PATCH" || true
+git push origin "releases/v$MAJOR"
+git tag -a "v$MAJOR.$MINOR.$PATCH" -m "release v$MAJOR.$MINOR.$PATCH"
+git push origin "v$MAJOR.$MINOR.$PATCH"
+
+cd "$CURRENT"
+rm -rf "$WORKING"

--- a/release.sh
+++ b/release.sh
@@ -1,13 +1,20 @@
 #!/bin/bash
 
-set -uex
+# The release flow is the following.
+#
+# 1. push transpiled TypeScript files into the releases/v1 branch
+# 2. create new tag v1.x.x on releases/v1 branch
+# 3. trigger workflows for building Redis binaries
+# 4. move v1 tag to v1.x.x
+#
+# ./prepare.sh does No.1 and 2, and ./release.sh does No.4
+#
+# 1. run `./prepare.sh 1.0.0`
+# 2. wait for all actions to finish. https://github.com/shogo82148/actions-setup-redis/actions
+# 3. run `./release.sh 1.0.0`
+# 4. publish new release on GitHub https://github.com/shogo82148/actions-setup-redis/releases
 
-CURRENT=$(cd "$(dirname "$0")" && pwd)
-VERSION=$1
-MAJOR=$(echo "$VERSION" | cut -d. -f1)
-MINOR=$(echo "$VERSION" | cut -d. -f2)
-PATCH=$(echo "$VERSION" | cut -d. -f3)
-WORKING=$CURRENT/.working
+set -uex
 
 : clone
 ORIGIN=$(git remote get-url origin)
@@ -15,24 +22,13 @@ rm -rf "$WORKING"
 git clone "$ORIGIN" "$WORKING"
 cd "$WORKING"
 
-: build the action
-git checkout -b "releases/v$MAJOR" "origin/releases/v$MAJOR" || git git checkout -b "releases/v$MAJOR" main
-git merge -X theirs -m "Merge branch 'main' into releases/v$MAJOR" main || true
-jq ".version=\"$MAJOR.$MINOR.$PATCH\"" < package.json > .tmp.json
-mv .tmp.json package.json
-npm ci
-npm run build
-
-: remove development packages from node_modules
-npm prune --production
-perl -ne 'print unless m(^/node_modules/|/lib/$)' -i .gitignore
-
-: publish to GitHub
-git add .
-git commit -m "bump up to v$MAJOR.$MINOR.$PATCH" || true
-git push origin "releases/v$MAJOR"
-git tag -a "v$MAJOR.$MINOR.$PATCH" -m "release v$MAJOR.$MINOR.$PATCH"
-git push origin "v$MAJOR.$MINOR.$PATCH"
+: release the action
+git checkout "v$MAJOR.$MINOR.$PATCH" || (
+    : it looks that "v$MAJOR.$MINOR.$PATCH" is not tagged.
+    : run ./prepare.sh "v$MAJOR.$MINOR.$PATCH" at first.
+    : see the comments of ./release.sh for more details.
+    exit 1
+)
 git tag -fa "v$MAJOR" -m "release v$MAJOR.$MINOR.$PATCH"
 git push -f origin "v$MAJOR"
 


### PR DESCRIPTION
separate the release flow into 2 scripts for avoiding 404 not found.

1. push transpiled TypeScript files into the releases/v1 branch
2. create new tag v1.x.x on releases/v1 branch
3. trigger workflows for building Redis binaries
4. move v1 tag to v1.x.x

./prepare.sh does No.1 and 2, and ./release.sh does No.4

1. run `./prepare.sh 1.0.0`
2. wait for all actions to finish. https://github.com/shogo82148/actions-setup-redis/actions
3. run `./release.sh 1.0.0`
4. publish new release on GitHub https://github.com/shogo82148/actions-setup-redis/releases
