### PR TITLE
validate the platform

### DIFF
--- a/src/installer.ts
+++ b/src/installer.ts
@@ -117,6 +117,14 @@ async function acquireRedis(version: string): Promise<string> {
 }
 
 function getFileName(version: string): string {
+  switch (osPlat) {
+    case 'linux':
+      break;
+    case 'darwin':
+      break;
+    default:
+      throw new Error(`unsupported platform: ${osPlat}`);
+  }
   return `redis-${version}-${osPlat}-${osArch}.tar.xz`;
 }
 


### PR DESCRIPTION
running the action on windows results the `BlobNotFound` error.
It is the expected result because Redis doesn't support Windows platform and we don't provide Windows binaries.
However, it might confuse the users.
So I fixed the error message as the following:

> unsupported platform: win32

fixes https://github.com/shogo82148/actions-setup-redis/issues/301