### PR TITLE
drop ubuntu 16.04 from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
         os:
           - ubuntu-20.04
           - ubuntu-18.04
-          - ubuntu-16.04
           - macos-11.0
           - macos-10.15
 


### PR DESCRIPTION
GitHub announced that ubuntu 16.04 will be removed.
https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/