### PR TITLE
fix: exit 1 on error

### DIFF
--- a/src/setup-redis.ts
+++ b/src/setup-redis.ts
@@ -38,4 +38,7 @@ async function run() {
   }
 }
 
-run();
+run().catch(e => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Hi, thanks very useful action

When `actions-setup-redis` occurred error, it print only `unhandledPromiseRejectionWarning` and exit success status.
I think the expected behavior is to failure Action when that situation.

So, I fixed