### PR TITLE
drop support of macos 10.15

### DIFF
--- a/.github/workflows/build-2.8.yml
+++ b/.github/workflows/build-2.8.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os:
           - ubuntu-18.04
-          - macos-10.15
+          - macos-11
         redis:
           - "2.8.24"
           - "2.8.23"

--- a/.github/workflows/build-3.0.yml
+++ b/.github/workflows/build-3.0.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os:
           - ubuntu-18.04
-          - macos-10.15
+          - macos-11
         redis:
           - "3.0.7"
           - "3.0.6"

--- a/.github/workflows/build-3.2.yml
+++ b/.github/workflows/build-3.2.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os:
           - ubuntu-18.04
-          - macos-10.15
+          - macos-11
         redis:
           - "3.2.13"
           - "3.2.12"

--- a/.github/workflows/build-4.0.yml
+++ b/.github/workflows/build-4.0.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os:
           - ubuntu-18.04
-          - macos-10.15
+          - macos-11
         redis:
           - "4.0.14"
           - "4.0.13"

--- a/.github/workflows/build-5.0.yml
+++ b/.github/workflows/build-5.0.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os:
           - ubuntu-18.04
-          - macos-10.15
+          - macos-11
         redis:
           - "5.0.14"
           - "5.0.13"

--- a/.github/workflows/build-6.0.yml
+++ b/.github/workflows/build-6.0.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os:
           - ubuntu-18.04
-          - macos-10.15
+          - macos-11
         redis:
           - "6.0.16"
           - "6.0.15"

--- a/.github/workflows/build-6.2.yml
+++ b/.github/workflows/build-6.2.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os:
           - ubuntu-18.04
-          - macos-10.15
+          - macos-11
         redis:
           - "6.2.7"
           - "6.2.6"

--- a/.github/workflows/build-7.0.yml
+++ b/.github/workflows/build-7.0.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os:
           - ubuntu-18.04
-          - macos-10.15
+          - macos-11
         redis:
           - "7.0.4"
           - "7.0.3"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
           - ubuntu-18.04
           - macos-12
           - macos-11
-          - macos-10.15
         redis:
           - "6.2"
           - "7.0"
@@ -59,7 +58,6 @@ jobs:
           - ubuntu-18.04
           - macos-12
           - macos-11
-          - macos-10.15
         redis:
           - "6.2"
           - "7.0"


### PR DESCRIPTION
- https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/
- https://github.com/actions/virtual-environments/issues/5583