### PR TITLE
drop ubuntu-18.04

### DIFF
--- a/.github/workflows/build-2.8.yml
+++ b/.github/workflows/build-2.8.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-18.04
+          - ubuntu-20.04
           - macos-11
         redis:
           - "2.8.24"

--- a/.github/workflows/build-3.0.yml
+++ b/.github/workflows/build-3.0.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-18.04
+          - ubuntu-20.04
           - macos-11
         redis:
           - "3.0.7"

--- a/.github/workflows/build-3.2.yml
+++ b/.github/workflows/build-3.2.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-18.04
+          - ubuntu-20.04
           - macos-11
         redis:
           - "3.2.13"

--- a/.github/workflows/build-4.0.yml
+++ b/.github/workflows/build-4.0.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-18.04
+          - ubuntu-20.04
           - macos-11
         redis:
           - "4.0.14"

--- a/.github/workflows/build-5.0.yml
+++ b/.github/workflows/build-5.0.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-18.04
+          - ubuntu-20.04
           - macos-11
         redis:
           - "5.0.14"

--- a/.github/workflows/build-6.0.yml
+++ b/.github/workflows/build-6.0.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-18.04
+          - ubuntu-20.04
           - macos-11
         redis:
           - "6.0.18"

--- a/.github/workflows/build-6.2.yml
+++ b/.github/workflows/build-6.2.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-18.04
+          - ubuntu-20.04
           - macos-11
         redis:
           - "6.2.11"

--- a/.github/workflows/build-7.0.yml
+++ b/.github/workflows/build-7.0.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-18.04
+          - ubuntu-20.04
           - macos-11
         redis:
           - "7.0.10"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,6 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-20.04
-          - ubuntu-18.04
           - macos-12
           - macos-11
         redis:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,6 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-20.04
-          - ubuntu-18.04
           - macos-12
           - macos-11
         redis:


### PR DESCRIPTION
ubuntu-18.04 is no longer available.