### PR TITLE
macos-13 is available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-20.04
+          - macos-13
           - macos-12
           - macos-11
         redis:


### PR DESCRIPTION
https://github.blog/changelog/2023-04-24-github-actions-macos-13-is-now-available/