### PR TITLE
use the default test runner

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,26 @@
+# dependabot config
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
 version: 2
 updates:
-  - package-ecosystem: npm
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
+    # Check the npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 10
     ignore:
-      # update too often, ignore patch releases
       - dependency-name: "@types/node"
-        update-types: ["version-update:semver-patch"]
+        update-types:
+          # We update the major version manually,
+          # because it should be the same as the runtime version.
+          - "version-update:semver-major"
+          # update too often, ignore patch releases
+          - "version-update:semver-patch"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
- 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,11 +1,9 @@
 module.exports = {
   clearMocks: true,
   moduleFileExtensions: ['js', 'ts'],
-  testEnvironment: 'node',
   testMatch: ['**/*.test.ts'],
-  testRunner: 'jest-circus/runner',
   transform: {
     '^.+\\.ts$': 'ts-jest'
   },
   verbose: true
-}
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "eslint-plugin-github": "^4.8.0",
         "eslint-plugin-jest": "^27.2.2",
         "jest": "^29.6.0",
-        "jest-circus": "^29.4.3",
         "prettier": "^2.8.8",
         "ts-jest": "^29.1.1",
         "typescript": "^5.1.6"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "eslint-plugin-github": "^4.8.0",
     "eslint-plugin-jest": "^27.2.2",
     "jest": "^29.6.0",
-    "jest-circus": "^29.4.3",
     "prettier": "^2.8.8",
     "ts-jest": "^29.1.1",
     "typescript": "^5.1.6"


### PR DESCRIPTION
jest-circus is now the default test runner.

https://jestjs.io/blog/2021/05/25/jest-27