### PR TITLE
Skip certificates generation if TLS is disabled

### DIFF
--- a/src/starter.ts
+++ b/src/starter.ts
@@ -88,6 +88,13 @@ ${configure}
 // generate certificates and keys, and returns the configure for redis.conf.
 // port of https://github.com/redis/redis/blob/763fd0941683eb64190daca6abab1f29a72a772e/utils/gen-test-certs.sh
 async function generateTestCerts(confPath: string, tlsPort: number, redisPath: string): Promise<string> {
+  if (tlsPort === 0) {
+    // TLS is disabled.
+    // skip TLS configuration.
+    core.setOutput("redis-tls-dir", "");
+    return "";
+  }
+
   // search bundled openssl
   const openssl = path.join(redisPath, "openssl");
   if (!(await exists(openssl))) {


### PR DESCRIPTION
close https://github.com/shogo82148/actions-setup-redis/issues/899

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling for cases where TLS is disabled to ensure smoother operation without TLS configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->