### PR TITLE
Support distribution input

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,11 @@ jobs:
           # The latest version that supports OpenSSL 1.1.1
           - "6.2"
 
-          # Ths latest version
+          # Ths latest version of Redis
           - "7.2"
+
+          # The latest version of Valkey
+          - "valkey-7.2"
 
     steps:
       - name: Checkout
@@ -65,6 +68,7 @@ jobs:
         redis:
           - "6.2"
           - "7.0"
+          - "valkey-7.2"
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -65,6 +65,25 @@ jobs:
 
 ## Configuration
 
+### distribution
+
+The distribution. The valid values are `redis` or `valkey`. The default value is `redis`.
+You can use `redis-` and `valkey-` prefixes in `redis-version` instead of the `distribution` input.
+For example, the following two workflows install Valkey 7.2.
+
+```yaml
+- uses: shogo82148/actions-setup-redis@v1
+  with:
+    distribution: "valkey"
+    redis-version: "7.2"
+```
+
+```yaml
+- uses: shogo82148/actions-setup-redis@v1
+  with:
+    redis-version: "valkey-7.2"
+```
+
 ### redis-version
 
 The version of Redis.

--- a/__tests__/installer.test.ts
+++ b/__tests__/installer.test.ts
@@ -29,7 +29,7 @@ describe("installer tests", () => {
   }, 100000);
 
   it("Acquires version of redis if no matching version is installed", async () => {
-    await installer.getRedis("2.x");
+    await installer.getRedis("redis", "2.x");
     const redisDir = path.join(toolDir, "redis", "2.8.24", os.arch());
 
     expect(await exists(`${redisDir}.complete`)).toBe(true);
@@ -38,7 +38,7 @@ describe("installer tests", () => {
 
   it("start and shutdown redis-server", async () => {
     const confPath = await fs.mkdtemp(tempDir + path.sep);
-    const redisPath = await installer.getRedis("4.x");
+    const redisPath = await installer.getRedis("redis", "4.x");
     const cli = path.join(redisPath, "redis-cli");
     await starter.startRedis({
       confPath,

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,10 @@ name: "actions-setup-redis"
 description: "setup redis database"
 author: "ICHINOSE Shogo"
 inputs:
+  distribution:
+    description: the distribution of redis
+    default: "redis"
+    required: true
   redis-version:
     description: the version of redis
     default: "latest"

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -26,7 +26,7 @@ interface Strategy {
 }
 
 interface Matrix {
-  redis: string[];
+  [key: string]: string[];
 }
 
 async function getAvailableVersions(distribution: string, minorVersion: string): Promise<string[]> {
@@ -44,7 +44,7 @@ async function getAvailableVersions(distribution: string, minorVersion: string):
   });
 
   const info = await promise;
-  return info.jobs.build.strategy.matrix.redis;
+  return info.jobs.build.strategy.matrix[distribution];
 }
 
 export interface Redis {
@@ -52,10 +52,10 @@ export interface Redis {
   version: string;
 }
 
-const minorVersions = {
+const minorVersions: { [key: string]: string[] } = {
   redis: ["7.2", "7.0", "6.2", "6.0", "5.0", "4.0", "3.2", "3.0", "2.8"],
   valkey: ["7.2"],
-} as { [key: string]: string[] };
+};
 
 async function determineVersion(distribution: string, version: string): Promise<Redis> {
   if (version.startsWith("redis-")) {

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -29,49 +29,78 @@ interface Matrix {
   redis: string[];
 }
 
-async function getAvailableVersions(minorVersion: string): Promise<string[]> {
+async function getAvailableVersions(distribution: string, minorVersion: string): Promise<string[]> {
   const promise = new Promise<Workflow>((resolve, reject) => {
-    fs.readFile(path.join(__dirname, "..", ".github", "workflows", `build-redis-${minorVersion}.yml`), (err, data) => {
-      if (err) {
-        reject(err);
-      }
-      const info = yaml.load(data.toString()) as Workflow;
-      resolve(info);
-    });
+    fs.readFile(
+      path.join(__dirname, "..", ".github", "workflows", `build-${distribution}-${minorVersion}.yml`),
+      (err, data) => {
+        if (err) {
+          reject(err);
+        }
+        const info = yaml.load(data.toString()) as Workflow;
+        resolve(info);
+      },
+    );
   });
 
   const info = await promise;
   return info.jobs.build.strategy.matrix.redis;
 }
 
-const minorVersions = ["7.2", "7.0", "6.2", "6.0", "5.0", "4.0", "3.2", "3.0", "2.8"];
+export interface Redis {
+  distribution: string;
+  version: string;
+}
 
-async function determineVersion(version: string): Promise<string> {
-  if (version === "latest") {
-    const availableVersions = await getAvailableVersions(minorVersions[0]);
-    return availableVersions[0];
+const minorVersions = {
+  redis: ["7.2", "7.0", "6.2", "6.0", "5.0", "4.0", "3.2", "3.0", "2.8"],
+  valkey: ["7.2"],
+} as { [key: string]: string[] };
+
+async function determineVersion(distribution: string, version: string): Promise<Redis> {
+  if (version.startsWith("redis-")) {
+    distribution = "redis";
+    version = version.substring("redis-".length);
+  } else if (version.startsWith("valkey-")) {
+    distribution = "valkey";
+    version = version.substring("valkey-".length);
   }
-  for (const minorVersion of minorVersions) {
-    const availableVersions = await getAvailableVersions(minorVersion);
+
+  if (!minorVersions[distribution]) {
+    throw new Error(`unsupported distribution: ${distribution}`);
+  }
+
+  if (version === "latest") {
+    const availableVersions = await getAvailableVersions(distribution, minorVersions[distribution][0]);
+    return {
+      distribution,
+      version: availableVersions[0],
+    };
+  }
+  for (const minorVersion of minorVersions[distribution]) {
+    const availableVersions = await getAvailableVersions(distribution, minorVersion);
     for (const v of availableVersions) {
       if (semver.satisfies(v, version)) {
-        return v;
+        return {
+          distribution,
+          version: v,
+        };
       }
     }
   }
   throw new Error("unable to get latest version");
 }
 
-export async function getRedis(version: string): Promise<string> {
-  const selected = await determineVersion(version);
+export async function getRedis(distribution: string, version: string): Promise<string> {
+  const selected = await determineVersion(distribution, version);
 
   // check cache
   let toolPath: string;
-  toolPath = tc.find("redis", selected);
+  toolPath = tc.find(selected.distribution, selected.version);
 
   if (!toolPath) {
     // download, extract, cache
-    toolPath = await acquireRedis(selected);
+    toolPath = await acquireRedis(selected.distribution, selected.version);
     core.info(`redis tool is cached under ${toolPath}`);
   }
 
@@ -84,11 +113,11 @@ export async function getRedis(version: string): Promise<string> {
   return toolPath;
 }
 
-async function acquireRedis(version: string): Promise<string> {
+async function acquireRedis(distribution: string, version: string): Promise<string> {
   //
   // Download - a tool installer intimately knows how to get the tool (and construct urls)
   //
-  const fileName = getFileName(version);
+  const fileName = getFileName(distribution, version);
   const downloadUrl = await getDownloadUrl(fileName);
   let downloadPath: string | null = null;
   try {
@@ -112,7 +141,7 @@ async function acquireRedis(version: string): Promise<string> {
   return await tc.cacheDir(extPath, "redis", version);
 }
 
-function getFileName(version: string): string {
+function getFileName(distribution: string, version: string): string {
   switch (osPlat) {
     case "linux":
       break;
@@ -121,7 +150,7 @@ function getFileName(version: string): string {
     default:
       throw new Error(`unsupported platform: ${osPlat}`);
   }
-  return `redis-${version}-${osPlat}-${osArch}.tar.zstd`;
+  return `${distribution}-${version}-${osPlat}-${osArch}.tar.zstd`;
 }
 
 interface PackageVersion {

--- a/src/setup-redis.ts
+++ b/src/setup-redis.ts
@@ -10,6 +10,7 @@ async function run(): Promise<void> {
   }
   try {
     const required = { required: true };
+    const distribution = core.getInput("distribution", required);
     const version = core.getInput("redis-version", required);
     const port = parseInt(core.getInput("redis-port", required));
     const tlsPort = parseInt(core.getInput("redis-tls-port", required));
@@ -17,7 +18,7 @@ async function run(): Promise<void> {
     const configure = core.getInput("redis-conf");
 
     const redisPath = await core.group("install redis", async (): Promise<string> => {
-      return await installer.getRedis(version);
+      return await installer.getRedis(distribution, version);
     });
     if (autoStart) {
       await core.group("start redis", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option `distribution` with valid values `redis` or `valkey`, defaulting to `redis`. This allows specifying the distribution of Redis versions.

- **Enhancements**
  - Added a new input parameter `distribution` to the setup action, making it a required field.
  - Updated the installer to determine and retrieve Redis versions based on different distributions.

- **Documentation**
  - Updated README with examples and explanations for the new `distribution` configuration option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->