### PR TITLE
drop macos-12 support

### DIFF
--- a/.github/workflows/build-redis-2.8.yml
+++ b/.github/workflows/build-redis-2.8.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-20.04
           - macos-14
-          - macos-12
+          - macos-13
         redis:
           - "2.8.24"
           - "2.8.23"

--- a/.github/workflows/build-redis-3.0.yml
+++ b/.github/workflows/build-redis-3.0.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-20.04
           - macos-14
-          - macos-12
+          - macos-13
         redis:
           - "3.0.7"
           - "3.0.6"

--- a/.github/workflows/build-redis-3.2.yml
+++ b/.github/workflows/build-redis-3.2.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-20.04
           - macos-14
-          - macos-12
+          - macos-13
         redis:
           - "3.2.13"
           - "3.2.12"

--- a/.github/workflows/build-redis-4.0.yml
+++ b/.github/workflows/build-redis-4.0.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-20.04
           - macos-14
-          - macos-12
+          - macos-13
         redis:
           - "4.0.14"
           - "4.0.13"

--- a/.github/workflows/build-redis-5.0.yml
+++ b/.github/workflows/build-redis-5.0.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-20.04
           - macos-14
-          - macos-12
+          - macos-13
         redis:
           - "5.0.14"
           - "5.0.13"

--- a/.github/workflows/build-redis-6.0.yml
+++ b/.github/workflows/build-redis-6.0.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-20.04
           - macos-14
-          - macos-12
+          - macos-13
         redis:
           - "6.0.20"
           - "6.0.19"

--- a/.github/workflows/build-redis-6.2.yml
+++ b/.github/workflows/build-redis-6.2.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-20.04
           - macos-14
-          - macos-12
+          - macos-13
         redis:
           - "6.2.14"
           - "6.2.13"

--- a/.github/workflows/build-redis-7.0.yml
+++ b/.github/workflows/build-redis-7.0.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-20.04
           - macos-14
-          - macos-12
+          - macos-13
         redis:
           - "7.0.15"
           - "7.0.14"

--- a/.github/workflows/build-redis-7.2.yml
+++ b/.github/workflows/build-redis-7.2.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-20.04
           - macos-14
-          - macos-12
+          - macos-13
         redis:
           - "7.2.5"
           - "7.2.4"

--- a/.github/workflows/build-redis-7.4.yml
+++ b/.github/workflows/build-redis-7.4.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-20.04
           - macos-14
-          - macos-12
+          - macos-13
         redis:
           - "7.4.0"
     permissions:

--- a/.github/workflows/build-valkey-7.2.yml
+++ b/.github/workflows/build-valkey-7.2.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-20.04
           - macos-14
-          - macos-12
+          - macos-13
         valkey:
           - "7.2.5"
     permissions:

--- a/.github/workflows/build-valkey-8.0.yml
+++ b/.github/workflows/build-valkey-8.0.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - ubuntu-20.04
           - macos-14
-          - macos-12
+          - macos-13
         valkey:
           - "8.0.0"
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
           - macos-15
           - macos-14
           - macos-13
-          - macos-12
         redis:
           # The latest version that supports OpenSSL 1.1.1
           - "6.2"
@@ -66,7 +65,6 @@ jobs:
           - macos-15
           - macos-14
           - macos-13
-          - macos-12
         redis:
           - "6.2"
           - "7.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the macOS version for build workflows from `macos-12` to `macos-13` across multiple Redis and Valkey versions, enhancing compatibility with newer macOS environments.
	- Added Redis version `7.4` to the `test-tls` job in the testing workflow.

- **Bug Fixes**
	- Removed `macos-12` from the testing workflow, ensuring builds are executed on supported macOS versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->