### PR TITLE
Valkey 8.0.2 and 7.2.8 are released.

### DIFF
--- a/.github/workflows/build-valkey-7.2.yml
+++ b/.github/workflows/build-valkey-7.2.yml
@@ -17,6 +17,9 @@ jobs:
           - macos-14
           - macos-13
         valkey:
+          - "7.2.8"
+          - "7.2.7"
+          - "7.2.6"
           - "7.2.5"
     permissions:
       contents: write

--- a/.github/workflows/build-valkey-8.0.yml
+++ b/.github/workflows/build-valkey-8.0.yml
@@ -17,6 +17,7 @@ jobs:
           - macos-14
           - macos-13
         valkey:
+          - "8.0.2"
           - "8.0.1"
           - "8.0.0"
     permissions:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflows to include additional Valkey versions:
		- Added Valkey 7.2.6, 7.2.7, and 7.2.8 to build workflow
		- Added Valkey 8.0.2 to build workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->