### PR TITLE
drop support of Ubuntu 20.04

### DIFF
--- a/.github/workflows/build-redis-2.8.yml
+++ b/.github/workflows/build-redis-2.8.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-22.04-arm
           - macos-14
           - macos-13

--- a/.github/workflows/build-redis-3.0.yml
+++ b/.github/workflows/build-redis-3.0.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-22.04-arm
           - macos-14
           - macos-13

--- a/.github/workflows/build-redis-3.2.yml
+++ b/.github/workflows/build-redis-3.2.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-22.04-arm
           - macos-14
           - macos-13

--- a/.github/workflows/build-redis-4.0.yml
+++ b/.github/workflows/build-redis-4.0.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-22.04-arm
           - macos-14
           - macos-13

--- a/.github/workflows/build-redis-5.0.yml
+++ b/.github/workflows/build-redis-5.0.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-22.04-arm
           - macos-14
           - macos-13

--- a/.github/workflows/build-redis-6.0.yml
+++ b/.github/workflows/build-redis-6.0.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-22.04-arm
           - macos-14
           - macos-13

--- a/.github/workflows/build-redis-6.2.yml
+++ b/.github/workflows/build-redis-6.2.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-22.04-arm
           - macos-14
           - macos-13

--- a/.github/workflows/build-redis-7.0.yml
+++ b/.github/workflows/build-redis-7.0.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-22.04-arm
           - macos-14
           - macos-13

--- a/.github/workflows/build-redis-7.2.yml
+++ b/.github/workflows/build-redis-7.2.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-22.04-arm
           - macos-14
           - macos-13

--- a/.github/workflows/build-redis-7.4.yml
+++ b/.github/workflows/build-redis-7.4.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-22.04-arm
           - macos-14
           - macos-13

--- a/.github/workflows/build-valkey-7.2.yml
+++ b/.github/workflows/build-valkey-7.2.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-22.04-arm
           - macos-14
           - macos-13

--- a/.github/workflows/build-valkey-8.0.yml
+++ b/.github/workflows/build-valkey-8.0.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-22.04-arm
           - macos-14
           - macos-13

--- a/.github/workflows/build-valkey-8.1.yml
+++ b/.github/workflows/build-valkey-8.1.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - ubuntu-22.04-arm
           - macos-14
           - macos-13

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
           - ubuntu-22.04-arm
           - ubuntu-24.04
           - ubuntu-22.04
-          - ubuntu-20.04
           - macos-15
           - macos-14
           - macos-13
@@ -75,7 +74,6 @@ jobs:
           - ubuntu-22.04-arm
           - ubuntu-24.04
           - ubuntu-22.04
-          - ubuntu-20.04
           - macos-15
           - macos-14
           - macos-13


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded continuous integration and testing environments to a newer Ubuntu release, ensuring builds and tests run on a more current and supported platform.
	- Removed outdated OS configurations from automated workflows to streamline the build and test processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->