### PR TITLE
add macos-26 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
           - ubuntu-22.04-arm
           - ubuntu-24.04
           - ubuntu-22.04
+          - macos-26
           - macos-15
           - macos-14
           - macos-13
@@ -74,6 +75,7 @@ jobs:
           - ubuntu-22.04-arm
           - ubuntu-24.04
           - ubuntu-22.04
+          - macos-26
           - macos-15
           - macos-14
           - macos-13


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded continuous integration coverage to include macOS 26 in the operating system matrix for both the standard and TLS test suites.
  * Ensures broader platform validation without altering existing test steps, control flow, or error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->