### PR TITLE
add Ubuntu 26.04 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,8 +71,10 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - ubuntu-26.04-arm
           - ubuntu-24.04-arm
           - ubuntu-22.04-arm
+          - ubuntu-26.04
           - ubuntu-24.04
           - ubuntu-22.04
           - macos-26


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded test coverage to include additional Ubuntu 26.04 variants in the continuous integration pipeline, improving compatibility validation across different operating system versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->